### PR TITLE
Ensure git package is absent when building from source

### DIFF
--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -37,6 +37,14 @@
   changed_when: false
   failed_when: false
   register: git_installed
+  
+- name: Ensure git package is absent (RedHat).
+  yum: "pkg=git state=absent"
+  when: ansible_os_family == 'RedHat'
+
+- name: Ensure git package is absent (Debian).
+  apt: "pkg=git state=absent"
+  when: ansible_os_family == 'Debian'
 
 - name: Build git.
   command: >


### PR DESCRIPTION
Without this if git package exists the build step will be skipped