### PR TITLE
Suppress warning when checking git version

### DIFF
--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -25,7 +25,9 @@
   when: ansible_os_family == 'Debian'
 
 - name: Get installed version
-  command: git --version
+  command: >
+    git --version
+    warn=no
   changed_when: false
   failed_when: false
   register: git_installed_version


### PR DESCRIPTION
The warning is a false positive as the usage of git in this case is
checking the version of git installed.