### PR TITLE
Deprecated "always_run" replaced with "check_mode"

### DIFF
--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -30,7 +30,7 @@
     warn=no
   changed_when: false
   failed_when: false
-  always_run: yes
+  check_mode: no
   register: git_installed_version
 
 - name: Force git install if the version numbers do not match


### PR DESCRIPTION
Latest `ansible` version produces following warning:
```
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version
2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```
This change fixes the warning.