### PR TITLE
Fix for "always_run" deprecation warning

### DIFF
--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -30,7 +30,7 @@
     warn=no
   changed_when: false
   failed_when: false
-  always_run: yes
+  check_mode: no
   register: git_installed_version
 
 - name: Force git install if the version numbers do not match


### PR DESCRIPTION
In ansible v2.2.1.0 getting deprecation warning:

```
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled
 by setting deprecation_warnings=False in ansible.cfg
```

This commit fixes it by replacing `always_run` with `check_mode`.