### PR TITLE
removing subversion-perl in RHEL

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -6,7 +6,6 @@ git_install_from_source_dependencies:
   - zlib-devel
   - perl-devel
   - openssl-devel
-  - subversion-perl
   - make
   - gcc
 


### PR DESCRIPTION
subversion-perl no longer exists in base RHEL 7 repos, role works without it.