### PR TITLE
Adding git subtree support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,3 +20,7 @@ git_install_from_source_force_update: false
 
 # Leave this at it's default.
 git_reinstall_from_source: false
+
+# The git subtree command is not supported by default when building from source.
+# Set this to true enables `git subtree` support.
+git_enable_subtree: false

--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -63,3 +63,10 @@
     - install
   when: (git_installed_version.rc != 0) or (git_reinstall_from_source | bool)
   become: true
+
+- name: Build git subtree.
+  shell:
+    cmd: make prefix={{ git_install_path }}; GITPATH=`git --exec-path`; install -m 755 git-subtree $GITPATH
+    chdir: /{{ workspace }}/git-{{ git_version }}/contrib/subtree
+  become: yes
+  when: git_enable_subtree | bool


### PR DESCRIPTION
`git subtree` is a popular git command and repo management strategy, but is not enabled by default when building git from source.

This PR enables subtree support when `git_enable_subtree` is enabled in defaults/main.yml